### PR TITLE
chore: remove dispatch_subscription_callback tracepoint

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -499,12 +499,6 @@ public:
     auto callback_ptr = static_cast<const void *>(this);
     auto rmw_info = message_info.get_rmw_message_info();
     auto source_timestamp = rmw_info.source_timestamp;
-    TRACEPOINT(
-      dispatch_subscription_callback,
-      message.get(),
-      callback_ptr,
-      source_timestamp,
-      static_cast<const uint64_t>(TimeStampRosMessage::value(*message).second));
     TRACEPOINT(callback_start, callback_ptr, false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {


### PR DESCRIPTION
# Description
By using rmw_take tracepoints to tie records in CARET, the `dispatch_subscription_callback` tracepoint is no longer a required tracepoint.
Unnecessary trace points must be deleted to prevent trace data from being lost.

# Related Links
- https://github.com/tier4/ros2_tracing/pull/4
- https://github.com/tier4/CARET_trace/pull/113
- https://github.com/tier4/CARET_analyze/pull/296

# Changes
- remove `dispatch_subscription_callback` tracepoint