### PR TITLE
feat: change publish trace point definition

### DIFF
--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -456,7 +456,7 @@ protected:
   {
     TRACEPOINT(
       rclcpp_publish,
-      nullptr,
+      static_cast<const void *>(publisher_handle_.get()),
       static_cast<const void *>(&msg));
     auto status = rcl_publish(publisher_handle_.get(), &msg, nullptr);
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -456,9 +456,8 @@ protected:
   {
     TRACEPOINT(
       rclcpp_publish,
-      static_cast<const void *>(publisher_handle_.get()),
-      static_cast<const void *>(&msg),
-      static_cast<const uint64_t>(TimeStampRosMessage::value(msg).second));
+      nullptr,
+      static_cast<const void *>(&msg));
     auto status = rcl_publish(publisher_handle_.get(), &msg, nullptr);
 
     if (RCL_RET_PUBLISHER_INVALID == status) {
@@ -524,8 +523,7 @@ protected:
     TRACEPOINT(
       rclcpp_intra_publish,
       static_cast<const void *>(publisher_handle_.get()),
-      msg.get(),
-      static_cast<const uint64_t>(TimeStampPubMessage::value(*msg).second));
+      msg.get());
 
     ipm->template do_intra_process_publish<PublishedType, ROSMessageType, AllocatorT>(
       intra_process_publisher_id_,
@@ -548,8 +546,7 @@ protected:
     TRACEPOINT(
       rclcpp_intra_publish,
       static_cast<const void *>(publisher_handle_.get()),
-      msg.get(),
-      static_cast<const uint64_t>(TimeStampRosMessage::value(*msg).second));
+      msg.get());
 
     ipm->template do_intra_process_publish<ROSMessageType, ROSMessageType, AllocatorT>(
       intra_process_publisher_id_,
@@ -572,8 +569,7 @@ protected:
     TRACEPOINT(
       rclcpp_intra_publish,
       static_cast<const void *>(publisher_handle_.get()),
-      msg.get(),
-      static_cast<const uint64_t>(TimeStampRosMessage::value(*msg).second));
+      msg.get());
 
     return ipm->template do_intra_process_publish_and_return_shared<ROSMessageType, ROSMessageType,
              AllocatorT>(


### PR DESCRIPTION
Some parts of the current CARET define their own trace points. For future development, information that is no longer needed (e.g. message_timestamp in rclcpp_publish) will be removed and the function signatures will be modified to match.