### PR TITLE
fix(rclcpp): fix 'rosbag record' error with ros-humble-rosbag-transport 0.15.7

### DIFF
--- a/rclcpp/include/rclcpp/clock.hpp
+++ b/rclcpp/include/rclcpp/clock.hpp
@@ -138,6 +138,51 @@ public:
     Context::SharedPtr context = contexts::get_global_default_context());
 
   /**
+   * Check if the clock is started.
+   *
+   * A started clock is a clock that reflects non-zero time.
+   * Typically a clock will be unstarted if it is using RCL_ROS_TIME with ROS time and
+   * nothing has been published on the clock topic yet.
+   *
+   * \return true if clock is started
+   * \throws std::runtime_error if the clock is not rcl_clock_valid
+   */
+  RCLCPP_PUBLIC
+  bool
+  started();
+
+  /**
+   * Wait until clock to start.
+   *
+   * \rclcpp::Clock::started
+   * \param context the context to wait in
+   * \return true if clock was already started or became started
+   * \throws std::runtime_error if the context is invalid or clock is not rcl_clock_valid
+   */
+  RCLCPP_PUBLIC
+  bool
+  wait_until_started(Context::SharedPtr context = contexts::get_global_default_context());
+
+  /**
+   * Wait for clock to start, with timeout.
+   *
+   * The timeout is waited in steady time.
+   *
+   * \rclcpp::Clock::started
+   * \param timeout the maximum time to wait for.
+   * \param context the context to wait in.
+   * \param wait_tick_ns the time to wait between each iteration of the wait loop (in nanoseconds).
+   * \return true if clock was or became valid
+   * \throws std::runtime_error if the context is invalid or clock is not rcl_clock_valid
+   */
+  RCLCPP_PUBLIC
+  bool
+  wait_until_started(
+    const rclcpp::Duration & timeout,
+    Context::SharedPtr context = contexts::get_global_default_context(),
+    const rclcpp::Duration & wait_tick_ns = rclcpp::Duration(0, static_cast<uint32_t>(1e7)));
+
+  /**
    * Returns the clock of the type `RCL_ROS_TIME` is active.
    *
    * \return true if the clock is active

--- a/rclcpp/package.xml
+++ b/rclcpp/package.xml
@@ -30,7 +30,7 @@
   <build_export_depend>rosidl_typesupport_cpp</build_export_depend>
 
   <depend>libstatistics_collector</depend>
-  <depend>rcl</depend>
+  <depend version_gte="5.3.4">rcl</depend> # https://github.com/ros2/rclcpp/pull/2252
   <depend>rcl_yaml_param_parser</depend>
   <depend>rcpputils</depend>
   <depend>rcutils</depend>


### PR DESCRIPTION
## Description

(TIER IV Internal) https://star4.slack.com/archives/CEV8XMJBV/p1692246995596909

I have corrected the problem where an error occurs while executing the rosbag record command with the ros-humble-rosbag-transport version 0.15.7.

```
[] Failed to load entry point 'record': /opt/ros/humble/lib/librosbag2_transport.so: undefined symbol: _ZN6rclcpp5Clock7startedEv
[] Traceback (most recent call last):
[]   File "/opt/ros/humble/bin/ros2", line 33, in <module>
[]     sys.exit(load_entry_point('ros2cli==0.18.7', 'console_scripts', 'ros2')())
[]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2cli/cli.py", line 50, in main
[]     add_subparsers_on_demand(
[]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2cli/command/__init__.py", line 250, in add_subparsers_on_demand
[]     extension.add_arguments(
[]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2bag/command/bag.py", line 26, in add_arguments
[]     add_subparsers_on_demand(
[]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2cli/command/__init__.py", line 237, in add_subparsers_on_demand
[]     extension = command_extensions[name]
[] KeyError: 'record'
[] Error in sys.excepthook:
[] Traceback (most recent call last):
```

## Test Performed

(TIER IV Internal) https://evaluation.tier4.jp/evaluation/reports/2ce275fc-c9d3-5897-9bb9-33098fd0071f?project_id=prd_jt