### PR TITLE
feat(GenericSubscription): Add dispatch subscription callback to generic subscription

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -497,14 +497,6 @@ public:
     const rclcpp::MessageInfo & message_info)
   {
     auto callback_ptr = static_cast<const void *>(this);
-    auto rmw_info = message_info.get_rmw_message_info();
-    auto source_timestamp = rmw_info.source_timestamp;
-    TRACEPOINT(
-      dispatch_subscription_callback,
-      message.get(),
-      callback_ptr,
-      source_timestamp,
-      static_cast<const uint64_t>(TimeStampRosMessage::value(*message).second));
     TRACEPOINT(callback_start, callback_ptr, false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -31,6 +31,7 @@
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/typesupport_helpers.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "tracetools/tracetools.h"
 
 namespace rclcpp
 {
@@ -119,6 +120,14 @@ public:
         options.event_callbacks.message_lost_callback,
         RCL_SUBSCRIPTION_MESSAGE_LOST);
     }
+    TRACEPOINT(
+      rclcpp_subscription_init,
+      static_cast<const void *>(get_subscription_handle().get()),
+      static_cast<const void *>(this));
+    TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      static_cast<const void *>(this),
+      static_cast<const void *>(&callback));
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -128,6 +128,13 @@ public:
       rclcpp_subscription_callback_added,
       static_cast<const void *>(this),
       static_cast<const void *>(&callback));
+
+#ifndef TRACETOOLS_DISABLED
+    TRACEPOINT(
+      rclcpp_callback_register,
+      static_cast<const void *>(&callback),
+      tracetools::get_symbol(callback));
+#endif
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -120,6 +120,7 @@ public:
         options.event_callbacks.message_lost_callback,
         RCL_SUBSCRIPTION_MESSAGE_LOST);
     }
+    auto callback_ptr = static_cast<const void *>(&callback_);
     TRACEPOINT(
       rclcpp_subscription_init,
       static_cast<const void *>(get_subscription_handle().get()),
@@ -127,12 +128,12 @@ public:
     TRACEPOINT(
       rclcpp_subscription_callback_added,
       static_cast<const void *>(this),
-      static_cast<const void *>(&callback));
+      callback_ptr);
 
 #ifndef TRACETOOLS_DISABLED
     TRACEPOINT(
       rclcpp_callback_register,
-      static_cast<const void *>(&callback),
+      callback_ptr,
       tracetools::get_symbol(callback));
 #endif
   }

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -26,7 +26,7 @@ void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
   TRACEPOINT(
     rclcpp_publish,
     static_cast<const void *>(publisher_handle_.get()),
-    static_cast<const void *>(&message));
+    static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);
 

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -23,6 +23,10 @@ namespace rclcpp
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
+  TRACEPOINT(
+    rclcpp_publish,
+    static_cast<const void *>(publisher_handle_.get()),
+    static_cast<const void *>(&message));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);
 

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -22,6 +22,8 @@
 
 #include "rclcpp/exceptions.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rclcpp
 {
 
@@ -46,11 +48,20 @@ void GenericSubscription::handle_message(
 void
 GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
-  const rclcpp::MessageInfo &)
+  const rclcpp::MessageInfo & message_info)
 {
-  TRACEPOINT(callback_start, static_cast<const void *>(this), false);
+    auto callback_ptr = static_cast<const void *>(&callback_);
+    auto rmw_info = message_info.get_rmw_message_info();
+    auto source_timestamp = rmw_info.source_timestamp;
+    TRACEPOINT(
+      dispatch_subscription_callback,
+      message.get(),
+      callback_ptr,
+      source_timestamp,
+      static_cast<const uint64_t>(rclcpp::TimeStamp<rclcpp::SerializedMessage>::value(*message).second));
+  TRACEPOINT(callback_start, callback_ptr, false);
   callback_(message);
-  TRACEPOINT(callback_end, static_cast<const void *>(this));
+  TRACEPOINT(callback_end, callback_ptr);
 }
 
 void GenericSubscription::handle_loaned_message(

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -22,8 +22,6 @@
 
 #include "rclcpp/exceptions.hpp"
 
-#include "tracetools/tracetools.h"
-
 namespace rclcpp
 {
 

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -58,7 +58,7 @@ GenericSubscription::handle_serialized_message(
       message.get(),
       callback_ptr,
       source_timestamp,
-      static_cast<const uint64_t>(rclcpp::TimeStamp<rclcpp::SerializedMessage>::value(*message).second));
+      0);
   TRACEPOINT(callback_start, callback_ptr, false);
   callback_(message);
   TRACEPOINT(callback_end, callback_ptr);

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -48,7 +48,9 @@ GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
   const rclcpp::MessageInfo &)
 {
+  TRACEPOINT(callback_start, static_cast<const void *>(this), false);
   callback_(message);
+  TRACEPOINT(callback_end, static_cast<const void *>(this));
 }
 
 void GenericSubscription::handle_loaned_message(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR will allow applications using GenericSubscription/GenericPublisher to be analyzed by CARET.
Add trace points to each class that are required for analysis in CARET. 
( see https://tier4.github.io/caret_doc/latest/design/trace_points/runtime_trace_points/. )

### Added tracepoints
- GenericPublisher
  - rclcpp_publsih
- GenericSubscription
  - rclcpp_subscription_init
  - rclcpp_subscription_callback_added
  - rclcpp_callback_register
  - dispatch_subscription_callback
  - callback_start
  - callback_end
  - dispatch_subscription_callback

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
