### PR TITLE
feat(caret): add caret trace points

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -25,6 +25,7 @@
 #include "rosidl_runtime_cpp/traits.hpp"
 #include "tracetools/tracetools.h"
 #include "tracetools/utils.hpp"
+#include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
 
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/detail/subscription_callback_type_helper.hpp"
@@ -32,6 +33,7 @@
 #include "rclcpp/message_info.hpp"
 #include "rclcpp/serialized_message.hpp"
 #include "rclcpp/type_adapter.hpp"
+#include "rclcpp/timestamp.hpp"
 
 
 template<class>
@@ -343,6 +345,8 @@ private:
 
     const T * pointer;
   };
+  using TimeStampRosMessage = rclcpp::TimeStamp<ROSMessageType>;
+  using TimeStampSubMessage = rclcpp::TimeStamp<SubscribedType>;
 
 public:
   explicit
@@ -492,7 +496,8 @@ public:
     std::shared_ptr<ROSMessageType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACEPOINT(callback_start, static_cast<const void *>(this), false);
+    auto callback_ptr = static_cast<const void *>(this);
+    TRACEPOINT(callback_start, callback_ptr, false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -592,6 +597,7 @@ public:
     std::shared_ptr<rclcpp::SerializedMessage> serialized_message,
     const rclcpp::MessageInfo & message_info)
   {
+    // cannot convert to a TypedMessage, caret insert dispatch tracepoint.
     TRACEPOINT(callback_start, static_cast<const void *>(this), false);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
@@ -671,7 +677,13 @@ public:
     std::shared_ptr<const SubscribedType> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+    auto callback_ptr = static_cast<const void *>(this);
+    TRACEPOINT(
+      dispatch_intra_process_subscription_callback,
+      message.get(),
+      callback_ptr,
+      static_cast<const uint64_t>(TimeStampSubMessage::value(*message).second));
+    TRACEPOINT(callback_start, callback_ptr, true);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {
@@ -801,7 +813,13 @@ public:
     std::unique_ptr<SubscribedType, SubscribedTypeDeleter> message,
     const rclcpp::MessageInfo & message_info)
   {
-    TRACEPOINT(callback_start, static_cast<const void *>(this), true);
+    auto callback_ptr = static_cast<const void *>(this);
+    TRACEPOINT(
+      dispatch_intra_process_subscription_callback,
+      message.get(),
+      callback_ptr,
+      static_cast<const uint64_t>(TimeStampSubMessage::value(*message).second));
+    TRACEPOINT(callback_start, callback_ptr, true);
     // Check if the variant is "unset", throw if it is.
     if (callback_variant_.index() == 0) {
       if (std::get<0>(callback_variant_) == nullptr) {

--- a/rclcpp/include/rclcpp/experimental/buffers/intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/buffers/intra_process_buffer.hpp
@@ -25,6 +25,8 @@
 #include "rclcpp/experimental/buffers/buffer_implementation_base.hpp"
 #include "rclcpp/macros.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rclcpp
 {
 namespace experimental
@@ -167,6 +169,7 @@ private:
     MessageDeleter * deleter = std::get_deleter<MessageDeleter, const MessageT>(shared_msg);
     auto ptr = MessageAllocTraits::allocate(*message_allocator_.get(), 1);
     MessageAllocTraits::construct(*message_allocator_.get(), ptr, *shared_msg);
+    TRACEPOINT(message_construct, shared_msg.get(), ptr);
     if (deleter) {
       unique_msg = MessageUniquePtr(ptr, *deleter);
     } else {
@@ -213,6 +216,7 @@ private:
     MessageDeleter * deleter = std::get_deleter<MessageDeleter, const MessageT>(buffer_msg);
     auto ptr = MessageAllocTraits::allocate(*message_allocator_.get(), 1);
     MessageAllocTraits::construct(*message_allocator_.get(), ptr, *buffer_msg);
+    TRACEPOINT(message_construct, buffer_msg.get(), ptr);
     if (deleter) {
       unique_msg = MessageUniquePtr(ptr, *deleter);
     } else {

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -39,6 +39,8 @@
 #include "rclcpp/type_adapter.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rclcpp
 {
 
@@ -229,6 +231,7 @@ public:
       // Construct a new shared pointer from the message
       // for the buffers that do not require ownership
       auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(allocator, *message);
+      TRACEPOINT(message_construct, message.get(), shared_msg.get());
 
       this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
         shared_msg, sub_ids.take_shared_subscriptions);
@@ -276,6 +279,7 @@ public:
       // Construct a new shared pointer from the message for the buffers that
       // do not require ownership and to return.
       auto shared_msg = std::allocate_shared<MessageT, MessageAllocatorT>(allocator, *message);
+      TRACEPOINT(message_construct, message.get(), shared_msg.get());
 
       if (!sub_ids.take_shared_subscriptions.empty()) {
         this->template add_shared_msg_to_buffers<MessageT, Alloc, Deleter, ROSMessageType>(
@@ -459,6 +463,7 @@ private:
           Deleter deleter = message.get_deleter();
           auto ptr = MessageAllocTraits::allocate(allocator, 1);
           MessageAllocTraits::construct(allocator, ptr, *message);
+          TRACEPOINT(message_construct, message.get(), ptr);
 
           subscription->provide_intra_process_data(std::move(MessageUniquePtr(ptr, deleter)));
         }

--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -31,6 +31,7 @@
 #include "rclcpp/subscription_base.hpp"
 #include "rclcpp/typesupport_helpers.hpp"
 #include "rclcpp/visibility_control.hpp"
+#include "tracetools/tracetools.h"
 
 namespace rclcpp
 {
@@ -119,6 +120,22 @@ public:
         options.event_callbacks.message_lost_callback,
         RCL_SUBSCRIPTION_MESSAGE_LOST);
     }
+    auto callback_ptr = static_cast<const void *>(&callback_);
+    TRACEPOINT(
+      rclcpp_subscription_init,
+      static_cast<const void *>(get_subscription_handle().get()),
+      static_cast<const void *>(this));
+    TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      static_cast<const void *>(this),
+      callback_ptr);
+
+#ifndef TRACETOOLS_DISABLED
+    TRACEPOINT(
+      rclcpp_callback_register,
+      callback_ptr,
+      tracetools::get_symbol(callback));
+#endif
   }
 
   RCLCPP_PUBLIC

--- a/rclcpp/include/rclcpp/timestamp.hpp
+++ b/rclcpp/include/rclcpp/timestamp.hpp
@@ -1,0 +1,115 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__TIMESTAMP_HPP_
+#define RCLCPP__TIMESTAMP_HPP_
+
+#include <type_traits>
+#include <utility>
+
+namespace rclcpp
+{
+// Sec ans Nanosec check
+template<typename M, typename = void>
+struct HasSec : public std::false_type
+{
+};
+
+template<typename M>
+struct HasSec<M, decltype((void)M::sec)>: std::true_type
+{
+};
+
+template<typename M, typename = void>
+struct HasNanoSec : public std::false_type
+{
+};
+
+template<typename M>
+struct HasNanoSec<M, decltype((void)M::nanosec)>: std::true_type
+{
+};
+
+template<typename M, typename Enable = void>
+struct TimeStampHeaderStamp
+{
+  static std::pair<bool, int64_t> value(const M &) {return std::make_pair(false, 0);}
+};
+
+template<typename M>
+struct TimeStampHeaderStamp<
+  M, typename std::enable_if<HasSec<M>::value && HasNanoSec<M>::value>::type>
+{
+  static std::pair<bool, int64_t> value(const M & m)
+  {
+    const auto nanos = RCL_S_TO_NS(static_cast<int64_t>(m.sec)) + m.nanosec;
+    return std::make_pair(true, nanos);
+  }
+};
+
+// Stamp check
+template<typename M, typename = void>
+struct HasStamp : public std::false_type
+{
+};
+
+template<typename M>
+struct HasStamp<M, decltype((void)M::stamp)>: std::true_type
+{
+};
+
+template<typename M, typename Enable = void>
+struct TimeStampHeader
+{
+  static std::pair<bool, int64_t> value(const M &) {return std::make_pair(false, 0);}
+};
+
+template<typename M>
+struct TimeStampHeader<M, typename std::enable_if<HasStamp<M>::value>::type>
+{
+  static std::pair<bool, int64_t> value(const M & m)
+  {
+    return TimeStampHeaderStamp<decltype(m.stamp)>::value(m.stamp);
+  }
+};
+
+// Header check
+template<typename M, typename = void>
+struct HasHeader : public std::false_type
+{
+};
+
+template<typename M>
+struct HasHeader<M, decltype((void)M::header)>: std::true_type
+{
+};
+
+template<typename M, typename Enable = void>
+struct TimeStamp
+{
+  static std::pair<bool, int64_t> value(const M &) {return std::make_pair(false, 0);}
+};
+
+template<typename M>
+struct TimeStamp<M, typename std::enable_if<HasHeader<M>::value>::type>
+{
+  static std::pair<bool, int64_t> value(const M & m)
+  {
+    return TimeStampHeader<decltype(m.header)>::value(m.header);
+  }
+};
+
+}  // namespace rclcpp
+
+#endif  // RCLCPP__TIMESTAMP_HPP_

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -23,6 +23,10 @@ namespace rclcpp
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
+  TRACEPOINT(
+    rclcpp_publish,
+    static_cast<const void *>(publisher_handle_.get()),
+    static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);
 

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -46,9 +46,20 @@ void GenericSubscription::handle_message(
 void
 GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
-  const rclcpp::MessageInfo &)
+  const rclcpp::MessageInfo & message_info)
 {
+    auto callback_ptr = static_cast<const void *>(&callback_);
+    auto rmw_info = message_info.get_rmw_message_info();
+    auto source_timestamp = rmw_info.source_timestamp;
+    TRACEPOINT(
+      dispatch_subscription_callback,
+      message.get(),
+      callback_ptr,
+      source_timestamp,
+      0);
+  TRACEPOINT(callback_start, callback_ptr, false);
   callback_(message);
+  TRACEPOINT(callback_end, callback_ptr);
 }
 
 void GenericSubscription::handle_loaned_message(


### PR DESCRIPTION
# Why this PR is needed

- Before 2024/5/13
  - Pilot.Auto uses [humble-with-fix-service-connection-patch](https://github.com/tier4/rclcpp/tree/humble-with-fix-service-connection-patch) branch
  - Pilot.Auto + CARET uses [humble-with-fix-service-connection-patch-tracepoint-added](https://github.com/tier4/rclcpp/tree/humble-with-fix-service-connection-patch-tracepoint-added) branch
    - Some trace points are added for CARET
- [t4-main](https://github.com/tier4/rclcpp/tree/t4-main) branch is created, and Pilot.Auto uses this branch to use glog from 2024/5/13
  - reference: https://github.com/tier4/rclcpp/pull/9
- A new branch for [t4-main](https://github.com/tier4/rclcpp/tree/t4-main) with CARET trace point needs to be created

# What this PR changes

- Create [t4-main-caret](https://github.com/tier4/rclcpp/tree/t4-main-caret) branch which is based on [t4-main](https://github.com/tier4/rclcpp/tree/t4-main) branch and the trace points for CARET are added

- The following command is used

```
git checkout t4-main
git checkout -b t4-main-caret
git checkout -b feat/add_trace_point
git merge origin/humble-with-fix-service-connection-patch-tracepoint-added
```

# Related changes

- Use the following branch for CARET meta repository  to import glog
  - [rclcpp-t4-main-caret](https://github.com/tier4/caret/tree/rclcpp-t4-main-caret) branch
  - Otherwise the following error occurs during CARET setup
    - `rclcpp_components: Cannot locate rosdep definition for [glog]`
- Use the following command to build Autoware with CARET with this branch to avoid packages conflict
  - `colcon build --symlink-install --packages-ignore rclcpp rclcpp_action rclcpp_components rclcpp_lifecycle glog --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=Off -DCMAKE_CXX_FLAGS="-w"`

# Confirmed items

- Only changes related to CARET trace point are added compared to the rclcpp without CARET
  - Differences of the followings are identical
  - reference changes: `origin/humble-with-fix-service-connection-patch` and `origin/humble-with-fix-service-connection-patch-tracepoint-added`
  - changes in this PR: `origin/t4-main` and `feat/add_trace_point`

- Only changes related to glog are added compared to the rclcpp used before 2024/5/13
  - Differences of the followings are identical
  - reference changes: `origin/humble-with-fix-service-connection-patch`  and `origin/t4-main`
  - changes in this PR: `origin/humble-with-fix-service-connection-patch-tracepoint-added` and `feat/add_trace_point`

- logging simulator and e2e simulator with Pilot.Auto (stable-main)  work as usual, and CARET analysis result is the same as before
- Stack trace from glog is output to launch.log (Code is modified to cause segmentation fault)

# Note

- Use `Create a merge commit` (don't use `Squash and merge` ) to keep merge history