### PR TITLE
fix(workaround): reduce the load on launch with CARET

### DIFF
--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -220,6 +220,10 @@ ComponentManager::on_load_node(
 {
   (void) request_header;
 
+  // Workaround for CARET
+  // Reduce the load on launch, otherwise some nodes may not be loaded
+  rclcpp::sleep_for(std::chrono::milliseconds(10 * 1000));
+
   try {
     auto resources = get_component_resources(request->package_name);
 


### PR DESCRIPTION
# Why this PR is needed

- Some nodes in a component container are not loaded occasionally with CARET
- It looks a "load_node" service response happens to disappear during launch due to the high load (not sure why)
  - While launching Autoware, so many nodes start. It causes very high load
  - Additionally, CARET records tracepoints when a node starts
- https://tier4.atlassian.net/browse/RT2-1818

# What this PR changes

- This PR adds a sleep at the beginning of  "load_node" so that all loading node processes are delayed, and which reduces the load on launch

# Notice

- This PR is workaround, and only for CARET
- Do not merge for main/t4-main branch
- Do not use "Squash" when merging to save operatioon log