### PR TITLE
feat(rclcpp_components): deduplicate node loading if FQN already exists

### DIFF
--- a/rclcpp_components/include/rclcpp_components/component_manager.hpp
+++ b/rclcpp_components/include/rclcpp_components/component_manager.hpp
@@ -165,18 +165,6 @@ protected:
   virtual void
   remove_node_from_executor(uint64_t node_id);
 
-  /// Check if a node with the same name already exists in the container
-  /**
-   * \param request information with the node to load
-   * \param response response to be filled if node already exists
-   * \return true if node already exists, false otherwise
-   */
-  RCLCPP_COMPONENTS_PUBLIC
-  virtual bool
-  check_node_duplication(
-    const std::shared_ptr<LoadNode::Request> request,
-    std::shared_ptr<LoadNode::Response> response);
-
   /// Service callback to load a new node in the component
   /**
    * This function allows to add parameters, remap rules, a specific node, name a namespace

--- a/rclcpp_components/src/component_manager.cpp
+++ b/rclcpp_components/src/component_manager.cpp
@@ -29,6 +29,62 @@ using namespace std::placeholders;
 
 namespace rclcpp_components
 {
+namespace
+{
+  /// Check if a node with the same name already exists in the container
+  /**
+   * \param request information with the node to load
+   * \param node_wrappers map of nodes in the container
+   * \param logger logger
+   * \param response response to be filled if node already exists
+   * \return true if node already exists, false otherwise
+   */
+bool check_node_duplication(
+  const std::shared_ptr<composition_interfaces::srv::LoadNode::Request> request,
+  const std::map<uint64_t, rclcpp_components::NodeInstanceWrapper> & node_wrappers,
+  const rclcpp::Logger & logger,
+  std::shared_ptr<composition_interfaces::srv::LoadNode::Response> response)
+{
+  if (request->node_name.empty()) {
+    return false;
+  }
+
+  const std::string & ns = request->node_namespace;
+  std::string requested_fqn;
+  if (ns.empty() || ns == "/") {
+    requested_fqn = "/" + request->node_name;
+  } else if (ns.back() == '/') {
+    requested_fqn = ns + request->node_name;
+  } else {
+    requested_fqn = ns + "/" + request->node_name;
+  }
+
+  // scan existing nodes
+  auto existing_node = std::find_if(
+    node_wrappers.cbegin(),
+    node_wrappers.cend(),
+    [&requested_fqn](const auto & kv) {
+      // Copy to call non-const method from const reference
+      auto wrapper = kv.second;
+      const auto base = wrapper.get_node_base_interface();
+      return base && base->get_fully_qualified_name() == requested_fqn;
+    });
+
+  if (existing_node != node_wrappers.cend()) {
+    // already exists -> return existing instance
+    response->full_node_name = requested_fqn;
+    response->unique_id = existing_node->first;
+    response->success = true;
+    RCLCPP_WARN(
+      logger,
+      "[LoadNode] Deduplicated : node '%s' already exists. Skipping load.",
+      requested_fqn.c_str());
+    return true;
+  }
+
+  return false;
+}
+} // namespace (anonymous)
 
 ComponentManager::ComponentManager(
   std::weak_ptr<rclcpp::Executor> executor,
@@ -212,49 +268,6 @@ ComponentManager::remove_node_from_executor(uint64_t node_id)
   }
 }
 
-bool
-ComponentManager::check_node_duplication(
-  const std::shared_ptr<LoadNode::Request> request,
-  std::shared_ptr<LoadNode::Response> response)
-{
-  if (request->node_name.empty()) {
-    return false;
-  }
-
-  const std::string & ns = request->node_namespace;
-  std::string requested_fqn;
-  if (ns.empty() || ns == "/") {
-    requested_fqn = "/" + request->node_name;
-  } else if (ns.back() == '/') {
-    requested_fqn = ns + request->node_name;
-  } else {
-    requested_fqn = ns + "/" + request->node_name;
-  }
-
-  // scan existing nodes
-  auto existing_node = std::find_if(
-    node_wrappers_.begin(),
-    node_wrappers_.end(),
-    [&requested_fqn](auto & kv) {
-      const auto base = kv.second.get_node_base_interface();
-      return base && base->get_fully_qualified_name() == requested_fqn;
-    });
-
-  if (existing_node != node_wrappers_.end()) {
-    // already exists -> return existing instance
-    response->full_node_name = requested_fqn;
-    response->unique_id = existing_node->first;
-    response->success = true;
-    RCLCPP_WARN(
-      get_logger(),
-      "[LoadNode] Deduplicated : node '%s' already exists. Skipping load.",
-      requested_fqn.c_str());
-    return true;
-  }
-
-  return false;
-}
-
 void
 ComponentManager::on_load_node(
   const std::shared_ptr<rmw_request_id_t> request_header,
@@ -265,7 +278,7 @@ ComponentManager::on_load_node(
 
   try {
     // check if node already exists in the container
-    if (check_node_duplication(request, response)) {
+    if (check_node_duplication(request, node_wrappers_, get_logger(), response)) {
       return;
     }
 


### PR DESCRIPTION
## Description
This PR adds a safeguard to the **LoadNode service** on the server side.  
When a LoadNode request is received, the server checks whether a node with the **same fully qualified name (including namespace)** already exists in the container before attempting to load it.

### Motivation
In the related PR, the client has been updated to **retry LoadNode requests** if no response is received within a certain timeout.  
Without this safeguard, retries could cause the same node to be loaded multiple times.
- https://github.com/tier4/launch_ros/pull/36

### Solution
- Prevents duplicate node loading by rejecting LoadNode requests for nodes that already exist in the container.

