### PR TITLE
fix: export CallbackGroup destructor symbol with default visibility

### DIFF
--- a/rclcpp/include/rclcpp/callback_group.hpp
+++ b/rclcpp/include/rclcpp/callback_group.hpp
@@ -95,6 +95,10 @@ public:
     CallbackGroupType group_type,
     bool automatically_add_to_executor_with_node = true);
 
+  /// Default destructor.
+  RCLCPP_PUBLIC
+  ~CallbackGroup();
+
   template<typename Function>
   rclcpp::SubscriptionBase::SharedPtr
   find_subscription_ptrs_if(Function func) const

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -27,6 +27,8 @@ CallbackGroup::CallbackGroup(
   automatically_add_to_executor_with_node_(automatically_add_to_executor_with_node)
 {}
 
+CallbackGroup::~CallbackGroup()
+{}
 
 std::atomic_bool &
 CallbackGroup::can_be_taken_from()

--- a/rclcpp/src/rclcpp/callback_group.cpp
+++ b/rclcpp/src/rclcpp/callback_group.cpp
@@ -28,7 +28,12 @@ CallbackGroup::CallbackGroup(
 {}
 
 CallbackGroup::~CallbackGroup()
-{}
+{
+  // NOTE: upstream rclcpp calls trigger_notify_guard_condition() here to notify the
+  // executor that this callback group is being destroyed. t4-main does not have the
+  // notify_guard_condition_ member or trigger_notify_guard_condition() method in CallbackGroup,
+  // so the destructor body is intentionally empty for now.
+}
 
 std::atomic_bool &
 CallbackGroup::can_be_taken_from()


### PR DESCRIPTION
## Summary

The `t4-main` branch is missing an explicit destructor for `rclcpp::CallbackGroup` that exists in the upstream `rolling` branch. This causes a runtime `undefined symbol` error at shutdown in executables linked against `libagnocast.so`:

```
symbol lookup error: libagnocast.so: undefined symbol: _ZN6rclcpp13CallbackGroupD1Ev
```

Demangled: `rclcpp::CallbackGroup::~CallbackGroup()`

Erros in Evaluator: https://evaluation.tier4.jp/evaluation/reports/cad22fd6-60d2-59f0-9c46-61e9be2f6342/tests/146a5fc6-8aa2-528a-8dcb-932941615908/f8013b02-ccd3-5a5c-ba33-67887994c083/348f1e62-6277-5aa5-8332-4f7b4b0f550d?project_id=autoware_dev

## Root Cause

### Missing explicit destructor in `t4-main`

| | System rclcpp ([`/opt/ros/rolling`](https://github.com/ros2/rclcpp/blob/87be5fbfd40deb0329c8e296fc41b6631358734f/rclcpp/include/rclcpp/callback_group.hpp#L105)) | Workspace rclcpp (`t4-main`) |
|---|---|---|
| Header (`callback_group.hpp`) | `RCLCPP_PUBLIC ~CallbackGroup();` | **No declaration** (implicit destructor) |
| Source (`callback_group.cpp`) | `CallbackGroup::~CallbackGroup() {}` | **No definition** |
| `librclcpp.so` symbol | `T _ZN6rclcpp13CallbackGroupD1Ev` (exported) | **Not exported** (hidden visibility) |

rclcpp uses `RCLCPP_PUBLIC` (`__attribute__((visibility("default")))`) to control symbol visibility. Without an explicit `RCLCPP_PUBLIC` destructor, the compiler generates an implicit destructor that is hidden by the default `-fvisibility=hidden` flag, so `librclcpp.so` does not export it.

### Why this causes a failure

Both `librclcpp.so` and `libagnocast.so` call `std::make_shared<rclcpp::CallbackGroup>()`, which instantiates the template class `std::_Sp_counted_ptr_inplace<CallbackGroup>` and its virtual method `_M_dispose()` (the deleter that calls `CallbackGroup::~CallbackGroup()`). These template instantiations are emitted as **weak symbols** (vague linkage) in each library.

The two libraries' `_M_dispose()` implementations differ in how they reference the destructor:

| | `librclcpp.so` | `libagnocast.so` |
|---|---|---|
| `_Sp_counted_ptr_inplace<CallbackGroup>::_M_dispose()` | WEAK DEFAULT (exported) | WEAK DEFAULT (exported) |
| `CallbackGroup::~CallbackGroup()` | **LOCAL (hidden)** — direct call, no PLT | **U (undefined)** — PLT call, needs dynamic resolution |
| vtable for `_Sp_counted_ptr_inplace<CallbackGroup>` | WEAK DEFAULT (exported) | WEAK DEFAULT (exported) |

Normally, GCC propagates `visibility("hidden")` from a type to its template instantiations, which would prevent interposition. However, `_Sp_counted_ptr_inplace<CallbackGroup>` is emitted with **default visibility** in both libraries. This is because libstdc++ defines `_Sp_counted_ptr_inplace` and its base class `_Sp_counted_base` under `#pragma GCC visibility push(default)`, and `CallbackGroup` has individual members (constructor, public methods) marked `RCLCPP_PUBLIC` (`visibility("default")`) — giving the type effective default visibility. Note that `RCLCPP_PUBLIC` is on individual members, not on the `class CallbackGroup` declaration itself. Only the implicit destructor, which lacks an explicit `RCLCPP_PUBLIC` declaration, falls back to hidden visibility under `-fvisibility=hidden`. This mismatch makes the control block subject to dynamic linker interposition while the destructor it calls remains unexportable.

When `libagnocast.so` is loaded **before** `librclcpp.so` in the dynamic linker's search order, the linker picks `libagnocast.so`'s definitions for the vtable and `_M_dispose()`:

```
1. Process starts; libagnocast.so is loaded before librclcpp.so
2. Dynamic linker interposes _Sp_counted_ptr_inplace<CallbackGroup>'s vtable
   → ALL instances (including those created inside librclcpp.so) use libagnocast.so's vtable
3. rclcpp::Node calls create_callback_group() → make_shared<CallbackGroup>() inside librclcpp.so
4. The shared_ptr's control block vtable points to libagnocast.so's _M_dispose()
5. At shutdown, shared_ptr is destroyed → vtable dispatches to libagnocast.so's _M_dispose()
6. libagnocast.so's _M_dispose() tries to resolve ~CallbackGroup() via PLT
7. librclcpp.so does not export this symbol (hidden) → symbol lookup error
```

This means the error occurs even when `agnocast::Node` is never used — any `shared_ptr<CallbackGroup>` created by the standard `rclcpp::Node` API is affected, because the vtable interposition redirects all destructor calls through `libagnocast.so`.

### Why other packages are not affected

Other packages create `CallbackGroup` instances through the standard rclcpp API:

```cpp
auto group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
```

This calls `rclcpp::node_interfaces::NodeBase::create_callback_group()`, which internally calls `std::make_shared<rclcpp::CallbackGroup>()` **inside `librclcpp.so`**. Since these packages do not themselves call `make_shared<CallbackGroup>()`, they do not instantiate `_Sp_counted_ptr_inplace<CallbackGroup>` and therefore do not introduce competing weak symbols.

A search across the entire workspace confirms that **agnocast is the only package outside of `librclcpp.so` that directly constructs `CallbackGroup`** via `std::make_shared` (all other packages use `node->create_callback_group()`).

## Fix

Add an explicit destructor with `RCLCPP_PUBLIC` visibility, matching the upstream `humble` branch:

- **Header**: Declare `RCLCPP_PUBLIC ~CallbackGroup();`
- **Source**: Define `CallbackGroup::~CallbackGroup() {}`

This ensures `librclcpp.so` exports the destructor symbol. Even when interposition causes `libagnocast.so`'s `_M_dispose()` to be used, the PLT lookup succeeds because the symbol is now in `librclcpp.so`'s dynamic symbol table.

Note: The upstream `humble` destructor calls `trigger_notify_guard_condition()`, but `t4-main` does not have that functionality, so the destructor body is intentionally empty.

## Test plan

- [x] Build rclcpp and verify `librclcpp.so` exports the destructor symbol: `nm -D librclcpp.so | grep CallbackGroupD`
- [x] Build agnocast and verify executables linked against `libagnocast.so` launch without the `undefined symbol` error: https://evaluation.tier4.jp/evaluation/reports/e1c0985a-1a42-5e70-902a-526bf46ebf3c?project_id=autoware_dev
