### PR TITLE
cherry-pick(26bcfed): retry service response send on failure

### DIFF
--- a/rclcpp/include/rclcpp/service.hpp
+++ b/rclcpp/include/rclcpp/service.hpp
@@ -495,7 +495,18 @@ public:
       return;
     }
     if (ret != RCL_RET_OK) {
-      rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
+      constexpr size_t retry_num = 100;
+      rcl_ret_t ret_2 = RCL_RET_NOT_INIT;
+      for (size_t i = 1; i < retry_num; ++i) {
+        rclcpp::sleep_for(std::chrono::milliseconds(100));
+        ret_2 = rcl_send_response(get_service_handle().get(), &req_id, &response);
+        if (ret_2 == RCL_RET_OK) {
+          break;
+        }
+      }
+      if (ret_2 != RCL_RET_OK) {
+        rclcpp::exceptions::throw_from_rcl_error(ret, "failed to send response");
+      }
     }
   }
 


### PR DESCRIPTION
## Description

cherry-pick of this https://github.com/tier4/rclcpp/commit/26bcfede386b8da597d2351b26f4b139adba0274

### Background

Originally in Humble/Galactic, there was an issue where a service server would throw an exception and terminate the node if it could not find the client when returning a response. https://github.com/ros2/ros2/issues/1253


In Autoware, this became problematic when loading composable nodes into a container, and nodes frequently died during startup.

At that time, as a temporary workaround, we handled this by sending the response repeatedly.

The upstream issue mentioned above was later addressed in https://github.com/ros2/rclcpp/pull/2276 , and therefore node termination is not expected to occur in the Jazzy branch.

**This cherry-pick is expected to be unnecessary. If confirmed, this PR will be closed.**

## TIER IV–specific Jazzy cherry-pick list

* https://github.com/tier4/rclcpp/pull/20
* https://github.com/tier4/rclcpp/pull/21
* https://github.com/tier4/rclcpp/pull/22