### PR TITLE
cherry-pick(#9): introduce glog

### DIFF
--- a/rclcpp_components/CMakeLists.txt
+++ b/rclcpp_components/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(composition_interfaces REQUIRED)
+find_package(glog REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 
@@ -54,7 +55,7 @@ add_executable(
   component_container
   src/component_container.cpp
 )
-target_link_libraries(component_container component_manager rclcpp::rclcpp)
+target_link_libraries(component_container component_manager rclcpp::rclcpp glog::glog)
 
 set(node_main_template_install_dir "share/${PROJECT_NAME}")
 install(FILES
@@ -65,13 +66,13 @@ add_executable(
   component_container_mt
   src/component_container_mt.cpp
 )
-target_link_libraries(component_container_mt component_manager rclcpp::rclcpp)
+target_link_libraries(component_container_mt component_manager rclcpp::rclcpp glog::glog)
 
 add_executable(
   component_container_isolated
   src/component_container_isolated.cpp
 )
-target_link_libraries(component_container_isolated component_manager rclcpp::rclcpp)
+target_link_libraries(component_container_isolated component_manager rclcpp::rclcpp glog::glog)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_libraries(component_container "stdc++fs")
@@ -90,7 +91,8 @@ if(BUILD_TESTING)
   set(components "")
   add_library(test_component SHARED test/components/test_component.cpp)
   target_link_libraries(test_component PRIVATE component)
-  #rclcpp_components_register_nodes(test_component "test_rclcpp_components::TestComponent")
+
+  # rclcpp_components_register_nodes(test_component "test_rclcpp_components::TestComponent")
   set(components "${components}test_rclcpp_components::TestComponentFoo;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentBar;$<TARGET_FILE:test_component>\n")
   set(components "${components}test_rclcpp_components::TestComponentNoNode;$<TARGET_FILE:test_component>\n")

--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -93,12 +93,15 @@ macro(rclcpp_components_register_node target)
     endif()
   endif()
 
+  find_package(glog QUIET REQUIRED)
+
   configure_file(${rclcpp_components_NODE_TEMPLATE}
     ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_configured_${node}.cpp.in)
   file(GENERATE OUTPUT ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_${node}.cpp
     INPUT ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_configured_${node}.cpp.in)
   add_executable(${node} ${PROJECT_BINARY_DIR}/rclcpp_components/node_main_${node}.cpp)
   target_link_libraries(${node}
+    glog::glog
     class_loader::class_loader
     rclcpp::rclcpp
     rclcpp_components::component

--- a/rclcpp_components/package.xml
+++ b/rclcpp_components/package.xml
@@ -20,11 +20,15 @@
   <build_depend>class_loader</build_depend>
   <build_depend>composition_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>glog</build_depend>
   <build_depend>rcpputils</build_depend>
+
+  <build_export_depend>glog</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>class_loader</exec_depend>
   <exec_depend>composition_interfaces</exec_depend>
+  <exec_depend>glog</exec_depend>
   <exec_depend>rclcpp</exec_depend>
 
   <test_depend>ament_cmake_google_benchmark</test_depend>
@@ -38,4 +42,3 @@
     <build_type>ament_cmake</build_type>
   </export>
 </package>
-

--- a/rclcpp_components/package.xml
+++ b/rclcpp_components/package.xml
@@ -20,15 +20,15 @@
   <build_depend>class_loader</build_depend>
   <build_depend>composition_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
-  <build_depend>glog</build_depend>
+  <build_depend>libgoogle-glog-dev</build_depend>
   <build_depend>rcpputils</build_depend>
 
-  <build_export_depend>glog</build_export_depend>
+  <build_export_depend>libgoogle-glog-dev</build_export_depend>
 
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>class_loader</exec_depend>
   <exec_depend>composition_interfaces</exec_depend>
-  <exec_depend>glog</exec_depend>
+  <exec_depend>libgoogle-glog-dev</exec_depend>
   <exec_depend>rclcpp</exec_depend>
 
   <test_depend>ament_cmake_google_benchmark</test_depend>

--- a/rclcpp_components/src/component_container.cpp
+++ b/rclcpp_components/src/component_container.cpp
@@ -1,4 +1,5 @@
 // Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2024 TIER IV, Inc. (Edit for glog)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 #include <memory>
+#include <glog/logging.h>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -20,6 +23,9 @@
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   /// Component container with a single-threaded executor.
   rclcpp::init(argc, argv);
   auto exec = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();

--- a/rclcpp_components/src/component_container_isolated.cpp
+++ b/rclcpp_components/src/component_container_isolated.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021 Open Source Robotics Foundation, Inc.
+// Copyright 2024 TIER IV, Inc. (Edit for glog)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <glog/logging.h>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/utilities.hpp"
@@ -22,6 +24,9 @@
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   /// Component container with dedicated single-threaded executors for each components.
   rclcpp::init(argc, argv);
   // parse arguments

--- a/rclcpp_components/src/component_container_mt.cpp
+++ b/rclcpp_components/src/component_container_mt.cpp
@@ -1,4 +1,5 @@
 // Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2024 TIER IV, Inc. (Edit for glog)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <glog/logging.h>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -20,6 +22,9 @@
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   /// Component container with a multi-threaded executor.
   rclcpp::init(argc, argv);
 

--- a/rclcpp_components/src/node_main.cpp.in
+++ b/rclcpp_components/src/node_main.cpp.in
@@ -1,4 +1,5 @@
 // Copyright 2019 Open Source Robotics Foundation, Inc.
+// Copyright 2024 TIER IV, Inc. (Edit for glog)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <glog/logging.h>
 
 #include "class_loader/class_loader.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -29,6 +31,9 @@ using namespace rclcpp::experimental::executors;
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   auto args = rclcpp::init_and_remove_ros_arguments(argc, argv);
   rclcpp::Logger logger = rclcpp::get_logger(NODE_MAIN_LOGGER_NAME);
   @executor@ exec;


### PR DESCRIPTION
## Description

[TIER IV INTERNAL ticket](https://tier4.atlassian.net/browse/T4DEV-50068)

This PR consists of three parts:
* Cherry-pick of PR #9
* Minor conflict resolution
* Replacement of `<depend>glog</depend>` with `<depend>libgoogle-glog-dev</depend>`

Originally, https://github.com/tier4/glog/tree/v0.6.0_t4-ros was used because the version of glog provided via apt in Humble did not have `IsGoogleLoggingInitialized`. So we needed to specify `<depend>glog</depend>` in package.xml
After the Jazzy environment, the apt-provided version includes this API, so tier4/rclcpp no longer needs to depend on tier4/glog. 
Now we can specify glog as  `<depend>libgoogle-glog-dev</depend>` .


> [!NOTE]
> However, some Autoware packages still have `<depend>glog</depend>` , so tier4/glog remains as a dependency in Autoware.
> related issues: https://github.com/autowarefoundation/autoware_universe/issues/12176

### Original PR's description

> Do not merge until double initialization is resolved.
> 
> Add glog to component containters and component node executable.

## How was this PR tested: 

I tested it with jazzy docker image.

```bash
# set up workspace
mkdir ros_ws/src -p
cd ros_ws/src
git clone git@github.com:tier4/rclcpp.git -b fix/jazzy/pr9
git clone https://github.com/ros2/demos.git -b jazzy
cd ..

# docker
docker run -it --rm -v (pwd):/ros2_ws -w /ros2_ws ros:jazzy
sudo apt update
rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to demo_nodes_cpp

# test phase
source install/setup.bash
ros2 run demo_nodes_cpp listener &
pkill listener
```

Here is dump result:
```
root@4d3cc8b682b2:/ros2_ws# pkill listener
*** Aborted at 1773290059 (unix time) try "date -d @1773290059" if you are using GNU date ***
root@4d3cc8b682b2:/ros2_ws# PC: @                0x0 (unknown)
*** SIGTERM (@0x2684) received by PID 9845 (TID 0x7f99721cbfc0) from PID 9860; stack trace: ***
    @     0x7f9972ef6206 (unknown)
    @     0x7f9972df8b4e rclcpp::SignalHandler::signal_handler()
    @     0x7f99726bf330 (unknown)
    @     0x7f9972712d71 (unknown)
    @     0x7f99727157ed pthread_cond_wait
    @     0x7f9970c094ca eprosima::fastdds::dds::detail::WaitSetImpl::wait()
    @     0x7f9970c0957c eprosima::fastdds::dds::WaitSet::wait()
    @     0x7f9971141a9e rmw_fastrtps_shared_cpp::__rmw_wait()
    @     0x7f99711a1928 rmw_wait
    @     0x7f997260f21c rcl_wait
    @     0x7f9972cf3648 rclcpp::WaitSetTemplate<>::wait<>()
    @     0x7f9972ceb90d rclcpp::Executor::wait_for_work()
    @     0x7f9972cebe2b rclcpp::Executor::get_next_executable()
    @     0x7f9972d0dd43 rclcpp::executors::SingleThreadedExecutor::spin()
    @     0x55951d183025 main
    @     0x7f99726a41ca (unknown)
    @     0x7f99726a428b __libc_start_main
    @     0x55951d183735 _start
[ros2run]: Terminated
```

## TIER IV–specific Jazzy cherry-pick list

* https://github.com/tier4/rclcpp/pull/20
* https://github.com/tier4/rclcpp/pull/21
* https://github.com/tier4/rclcpp/pull/22